### PR TITLE
feat: Rename project to control-deck-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Control Deck
+# Control Deck UI
 
 A standalone UI for managing LLM agents with specialized capabilities.
 
 ## Overview
 
-Control Deck provides a comprehensive interface for interacting with AI agents, each specialized in different domains such as research, coding, analysis, and creative writing. The application features a sidebar for agent selection and a main chat area for conversations.
+Control Deck UI provides a comprehensive interface for interacting with AI agents, each specialized in different domains such as research, coding, analysis, and creative writing. The application features a sidebar for agent selection and a main chat area for conversations.
 
 ## Features
 
@@ -178,10 +178,10 @@ Build and run with Docker:
 
 ```bash
 # Build image
-docker build -t control-deck .
+docker build -t control-deck-ui .
 
 # Run container
-docker run -p 3000:3000 control-deck
+docker run -p 3000:3000 control-deck-ui
 ```
 
 ## CI/CD

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "control-deck",
+  "name": "control-deck-ui",
   "version": "1.0.0",
   "private": true,
   "type": "module",
@@ -22,8 +22,8 @@
     "unit-test": "vitest run tests/unit",
     "intg-test": "vitest run tests/intg",
     "next-build-test": "next build",
-    "image-build-test": "docker build -t control-deck:build-test . && docker image rm control-deck:build-test",
-    "build-test": "next build && docker build --build-arg API_HOST=127.0.0.1 --build-arg API_PORT=8001 -t control-deck:build-test . && docker image rm control-deck:build-test",
+    "image-build-test": "docker build -t control-deck-ui:build-test . && docker image rm control-deck-ui:build-test",
+    "build-test": "next build && docker build --build-arg API_HOST=127.0.0.1 --build-arg API_PORT=8001 -t control-deck-ui:build-test . && docker image rm control-deck-ui:build-test",
     "clean": "rm -rf .next node_modules dev_server.log coverage dist"
   },
   "dependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const dmMono = DM_Mono({
 })
 
 export const metadata: Metadata = {
-  title: 'Control Deck',
+  title: 'Control Deck UI',
   description:
     'A modern task management interface for local LLM agents built with Next.js, Tailwind CSS, and TypeScript.'
 }

--- a/src/components/agents/AgentListSidebar.tsx
+++ b/src/components/agents/AgentListSidebar.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils'
 
 const SidebarHeader = () => (
   <div className="flex items-center gap-2 p-2">
-    <Heading size={2}>Control Deck</Heading>
+    <Heading size={2}>Control Deck UI</Heading>
   </div>
 )
 

--- a/src/components/chat/ChatArea/Messages/ChatBlankState.tsx
+++ b/src/components/chat/ChatArea/Messages/ChatBlankState.tsx
@@ -32,7 +32,7 @@ const ChatBlankState = () => {
     >
       <div className="flex max-w-3xl flex-col gap-y-4">
         <Heading size={1} className="tracking-tight">
-          Control Deck
+          Control Deck UI
         </Heading>
       </div>
     </section>

--- a/tests/unit/components/chat/ChatArea/Messages/ChatBlankState.test.tsx
+++ b/tests/unit/components/chat/ChatArea/Messages/ChatBlankState.test.tsx
@@ -31,14 +31,14 @@ describe('ChatBlankState', () => {
     expect(screen.getByText(mockAgent.description)).toBeInTheDocument()
   })
 
-  it('should display "Control Deck" heading when no agent is selected', () => {
+  it('should display "Control Deck UI" heading when no agent is selected', () => {
     mockUseStore.mockReturnValue({
       selectedAgent: null
     } as any)
 
     render(<ChatBlankState />)
 
-    expect(screen.getByText('Control Deck')).toBeInTheDocument()
+    expect(screen.getByText('Control Deck UI')).toBeInTheDocument()
   })
 
   it('should render different content based on selectedAgent state', () => {
@@ -59,7 +59,7 @@ describe('ChatBlankState', () => {
     } as any)
 
     rerender(<ChatBlankState />)
-    expect(screen.getByText('Control Deck')).toBeInTheDocument()
+    expect(screen.getByText('Control Deck UI')).toBeInTheDocument()
     expect(screen.queryByText(mockAgent.name)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
This commit renames the project from `control-deck` to `control-deck-ui` to better reflect its purpose as a user interface.

Changes include:
- Updated `package.json` with the new project name and adjusted Docker image names in scripts.
- Modified `README.md` to replace all instances of "Control Deck" with "Control Deck UI" and updated Docker commands.
- Changed the application title in `src/app/layout.tsx`.
- Updated component and test files to use the new "Control Deck UI" name.

All hardcoded instances of the old project name have been updated to ensure consistency across the application.